### PR TITLE
fix(bug): add -Region parameter to Get-RoleCredential (closes #63)

### DIFF
--- a/AWSAutomation.psd1
+++ b/AWSAutomation.psd1
@@ -9,7 +9,7 @@
     RootModule        = 'AWSAutomation.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.9.1'
+    ModuleVersion     = '0.9.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Public/Get-RoleCredential.ps1
+++ b/Public/Get-RoleCredential.ps1
@@ -18,6 +18,8 @@ function Get-RoleCredential {
         Value provided by MFA device
     .PARAMETER DurationInSeconds
         Duration of temporary credential in seconds
+    .PARAMETER Region
+        AWS region used for the STS endpoint when assuming the role. Defaults to us-east-1.
     .INPUTS
         None.
     .OUTPUTS
@@ -58,7 +60,11 @@ function Get-RoleCredential {
 
         [Parameter(HelpMessage = 'Duration of temporary credential in seconds')]
         [ValidateNotNullOrEmpty()]
-        [System.Int32] $DurationInSeconds = 3600
+        [System.Int32] $DurationInSeconds = 3600,
+
+        [Parameter(HelpMessage = 'AWS region for the STS endpoint')]
+        [ValidateNotNullOrEmpty()]
+        [System.String] $Region = 'us-east-1'
     )
 
     Begin {
@@ -78,6 +84,7 @@ function Get-RoleCredential {
         $stsParams = @{
             RoleSessionName   = 'SwitchToChild'
             DurationInSeconds = $DurationInSeconds # AWS DEFAULT IS 3600 (1 HOUR)
+            Region            = $Region            # REQUIRED BY AWS.TOOLS V5 / SDK V4 STS ENDPOINT RESOLUTION
         }
 
         # ADD MFA SERIAL AND CODE IF PROVIDED


### PR DESCRIPTION
## Summary

`Get-RoleCredential` was prompting for `Region:` in non-interactive shells because its inner call to `Use-STSRole` had no region to resolve. Under AWS.Tools v5 / AWS SDK for .NET v4, STS no longer has an implicit global endpoint, so a region must come from somewhere — the cmdlet falls back to an interactive prompt when none is available.

Closes #63.

## Changes

- Add optional `-Region` parameter to `Get-RoleCredential` (default `us-east-1`).
- Forward `-Region` to `Use-STSRole` via the existing `$stsParams` splat.
- Document the new parameter in the comment-based help.

## Validation

- [x] CI green
- [x] Manual: in a fresh shell with no `Set-DefaultAWSRegion` and no `AWS_REGION` env var, `Get-RoleCredential` no longer prompts for Region.
- [ ] Manual: passing `-Region us-west-2` is honored.